### PR TITLE
[Story-Feature] redirect after adding blank rental id is undefined

### DIFF
--- a/apps/web/module/Hosting/Listings/components/modals/SelectListingTypeModal.tsx
+++ b/apps/web/module/Hosting/Listings/components/modals/SelectListingTypeModal.tsx
@@ -43,7 +43,7 @@ const SelectListingTypeModal = ({ isOpen, onClose }: Props) => {
       onSuccess: (data: any) => {
         if (!data.error) {
           router.push(
-            `/hosting/listings/rentals/setup/${data.item.id}/basic-info`
+            `/hosting/listings/rentals/setup/${data.item._id}/basic-info`
           )
         } else {
           toast.error(String(data.message))


### PR DESCRIPTION
## REMINDER OF THE REQUIRED ACTIONS

- [x] No console message/errors/warning thrown to the logs
- [x] Have run `pnpm run build` and no failing builds shown
- [x] Commit messages was squashed to a single commit [Tutorial](https://www.youtube.com/watch?v=DLadleLj0ic)
- [x] Reviewers were tagged in the PR sidebar
- [x] Assignees was tagged in the PR sidebar
- [x] Labels was added in the PR sidebar
- [x] Project was added in the PR sidebar
- [x] Milestone was added in the PR sidebar

## INSERT PR DESCRIPTION BELOW

### Comments
Fixed redirect after adding blank rental id is undefined
