### PR TITLE
[Story-Feature] Converted get activity finished section to api v2

### DIFF
--- a/apps/api/src/routes/api/activities-v2/index.ts
+++ b/apps/api/src/routes/api/activities-v2/index.ts
@@ -13,6 +13,7 @@ import {
 import { addActivity, getActivity } from './services/default'
 import { getActivityInclusions } from './services/activity-inclussions'
 import { updateStatus } from './services/status'
+import { getFinishedSections } from './services/finishedSection'
 
 const router = express.Router()
 
@@ -80,6 +81,14 @@ router.patch(
   isUserLoggedIn,
   isHostActivityOwner,
   updateStatus
+)
+//finished sections
+router.get(
+  '/:activityId/finished-sections',
+  isOriginValid,
+  isUserLoggedIn,
+  isHostActivityOwner,
+  getFinishedSections
 )
 
 export default router

--- a/apps/api/src/routes/api/activities-v2/services/finishedSection.ts
+++ b/apps/api/src/routes/api/activities-v2/services/finishedSection.ts
@@ -1,0 +1,28 @@
+import { Request, Response } from 'express'
+import { ResponseService } from '@/common/service/response'
+import { UNKNOWN_ERROR_OCCURRED } from '@/common/constants'
+import { dbActivities } from '@repo/database'
+
+const response = new ResponseService()
+export const getFinishedSections = async (req: Request, res: Response) => {
+  const activityId = req.params.activityId
+  const hostId = res.locals.user?.host
+
+  try {
+    const activity = await dbActivities.findById({
+      _id: activityId,
+      host: hostId,
+    })
+
+    const finishedSections = activity?.finishedSections
+      ? (activity?.finishedSections as unknown as string)
+      : []
+    res.json(response.success({ item: { finishedSections } }))
+  } catch (err: any) {
+    return res.json(
+      response.error({
+        message: err.message ? err.message : UNKNOWN_ERROR_OCCURRED,
+      })
+    )
+  }
+}


### PR DESCRIPTION
## REMINDER OF THE REQUIRED ACTIONS

- [x] No console message/errors/warning thrown to the logs
- [x] Have run `pnpm run build` and no failing builds shown
- [x] Commit messages was squashed to a single commit [Tutorial](https://www.youtube.com/watch?v=DLadleLj0ic)
- [x] Reviewers were tagged in the PR sidebar
- [x] Assignees was tagged in the PR sidebar
- [x] Labels was added in the PR sidebar
- [x] Project was added in the PR sidebar
- [x] Milestone was added in the PR sidebar

## INSERT PR DESCRIPTION BELOW

Converted get activity finished section to api v2. This is tested.

### Screenshots or Video

![Screenshot 2024-06-07 091448](https://github.com/explore-siargao/es-main/assets/107088283/14c5af27-7fbf-43bd-9615-d2c956a82117)

