### PR TITLE
[Story-Feature] Implemented get activity finished sections api v2

### DIFF
--- a/apps/web/common/components/AdminLayout/NewListingActivitySidebar.tsx
+++ b/apps/web/common/components/AdminLayout/NewListingActivitySidebar.tsx
@@ -20,7 +20,7 @@ interface HostSidebarProps {
 
 const Sidebar = ({ children }: HostSidebarProps) => {
   const params = useParams<{ listingId: string }>()
-  const listingId = Number(params.listingId)
+  const listingId = String(params.listingId)
   const { data } = useGetFinishedSections({ listingId, type: "activity" })
   const finishedSections = data?.item?.finishedSections || []
   const ACTIVITY_SETUP_BASE_PATH = "/hosting/listings/activities/setup"

--- a/apps/web/common/components/AdminLayout/NewListingRentalSidebar.tsx
+++ b/apps/web/common/components/AdminLayout/NewListingRentalSidebar.tsx
@@ -22,7 +22,7 @@ interface HostSidebarProps {
 
 const Sidebar = ({ children }: HostSidebarProps) => {
   const params = useParams<{ listingId: string }>()
-  const listingId = Number(params.listingId)
+  const listingId = String(params.listingId)
   const { data } = useGetFinishedSections({ listingId, type: "rental" })
   const finishedSections = data?.item?.finishedSections || []
   const RENTAL_SETUP_BASE_PATH = "/hosting/listings/rentals/setup"

--- a/apps/web/common/components/AdminLayout/NewListingSidebar.tsx
+++ b/apps/web/common/components/AdminLayout/NewListingSidebar.tsx
@@ -24,7 +24,7 @@ interface HostSidebarProps {
 
 const Sidebar = ({ children }: HostSidebarProps) => {
   const params = useParams<{ listingId: string }>()
-  const listingId = Number(params.listingId)
+  const listingId = String(params.listingId)
   const { data } = useGetFinishedSections({ listingId, type: "property" })
   const finishedSections = data?.item?.finishedSections || []
   const PROPERTY_SETUP_BASE_PATH = "/hosting/listings/properties/setup"

--- a/apps/web/common/components/HostLayout/NewListingActivitySidebar.tsx
+++ b/apps/web/common/components/HostLayout/NewListingActivitySidebar.tsx
@@ -20,7 +20,7 @@ interface HostSidebarProps {
 
 const Sidebar = ({ children }: HostSidebarProps) => {
   const params = useParams<{ listingId: string }>()
-  const listingId = Number(params.listingId)
+  const listingId = String(params.listingId)
   const { data } = useGetFinishedSections({ listingId, type: "activity" })
   const finishedSections = data?.item?.finishedSections || []
   const ACTIVITY_SETUP_BASE_PATH = "/hosting/listings/activities/setup"

--- a/apps/web/common/components/HostLayout/NewListingRentalSidebar.tsx
+++ b/apps/web/common/components/HostLayout/NewListingRentalSidebar.tsx
@@ -22,7 +22,7 @@ interface HostSidebarProps {
 
 const Sidebar = ({ children }: HostSidebarProps) => {
   const params = useParams<{ listingId: string }>()
-  const listingId = Number(params.listingId)
+  const listingId = String(params.listingId)
   const { data } = useGetFinishedSections({ listingId, type: "rental" })
   const finishedSections = data?.item?.finishedSections || []
   const RENTAL_SETUP_BASE_PATH = "/hosting/listings/rentals/setup"

--- a/apps/web/common/components/HostLayout/NewListingSidebar.tsx
+++ b/apps/web/common/components/HostLayout/NewListingSidebar.tsx
@@ -24,7 +24,7 @@ interface HostSidebarProps {
 
 const Sidebar = ({ children }: HostSidebarProps) => {
   const params = useParams<{ listingId: string }>()
-  const listingId = Number(params.listingId)
+  const listingId = String(params.listingId)
   const { data } = useGetFinishedSections({ listingId, type: "property" })
   const finishedSections = data?.item?.finishedSections || []
   const PROPERTY_SETUP_BASE_PATH = "/hosting/listings/properties/setup"

--- a/apps/web/module/Hosting/Listings/Activities/hooks/useUpdateActivityInclusions.ts
+++ b/apps/web/module/Hosting/Listings/Activities/hooks/useUpdateActivityInclusions.ts
@@ -4,20 +4,20 @@ import { useMutation } from "@tanstack/react-query"
 import { T_Update_Activity_Inclusions } from "@repo/contract"
 
 export async function updateActivityInclusions(
-  ActivityId: string | undefined,
+  activityId: string | undefined,
   props: T_Update_Activity_Inclusions
 ) {
   const apiService = new ApiService("v2")
   return await apiService.patch(
-    `${API_URL_ACTIVITIES}/${ActivityId}/inclusions`,
+    `${API_URL_ACTIVITIES}/${activityId}/inclusions`,
     props
   )
 }
 
-function useUpdateActivityInclusions(ActivityId: string | undefined) {
+function useUpdateActivityInclusions(activityId: string | undefined) {
   const query = useMutation({
     mutationFn: (props: T_Update_Activity_Inclusions) =>
-      updateActivityInclusions(ActivityId, props),
+      updateActivityInclusions(activityId, props),
   })
   return query
 }

--- a/apps/web/module/Hosting/Listings/hooks/useGetFinishedSections.ts
+++ b/apps/web/module/Hosting/Listings/hooks/useGetFinishedSections.ts
@@ -6,10 +6,10 @@ import {
 import { ApiService } from "@/common/service/api"
 import { useQuery } from "@tanstack/react-query"
 
-type Props = { listingId: number; type: "property" | "rental" | "activity" }
+type Props = { listingId: string; type: "property" | "rental" | "activity" }
 
 export async function getFinishedSections({ listingId, type }: Props) {
-  const apiService = new ApiService("mock")
+  const apiService = new ApiService("v2")
   const baseUrl = {
     property: API_URL_PROPERTIES,
     rental: API_URL_RENTALS,


### PR DESCRIPTION
## REMINDER OF THE REQUIRED ACTIONS

- [x] No console message/errors/warning thrown to the logs
- [x] Have run `pnpm run build` and no failing builds shown
- [x] Commit messages was squashed to a single commit [Tutorial](https://www.youtube.com/watch?v=DLadleLj0ic)
- [x] Reviewers were tagged in the PR sidebar
- [x] Assignees was tagged in the PR sidebar
- [x] Labels was added in the PR sidebar
- [x] Project was added in the PR sidebar
- [x] Milestone was added in the PR sidebar

## INSERT PR DESCRIPTION BELOW

Implemented get activity finished sections api v2. Tested.


![Screenshot 2024-06-10 115408](https://github.com/explore-siargao/es-main/assets/107088283/fa5b7861-cbdc-42bd-95ba-441701a5e5b5)

