### PR TITLE
[Bug-Feature] Property Edit Mode return NaN propertyId

### DIFF
--- a/apps/web/common/components/HostLayout/ListingSidebar.tsx
+++ b/apps/web/common/components/HostLayout/ListingSidebar.tsx
@@ -23,7 +23,7 @@ interface HostSidebarProps {
 
 const Sidebar = ({ children }: HostSidebarProps) => {
   const params = useParams<{ listingId: string }>()
-  const listingId = Number(params.listingId)
+  const listingId = String(params.listingId)
   const PROPERTY_EDIT_BASE_PATH = "/hosting/listings/properties"
   const TOP_LINKS = [
     {


### PR DESCRIPTION
## REMINDER OF THE REQUIRED ACTIONS

- [x] No console message/errors/warning thrown to the logs
- [x] Have run `pnpm run build` and no failing builds shown
- [x] Commit messages was squashed to a single commit [Tutorial](https://www.youtube.com/watch?v=DLadleLj0ic)
- [x] Reviewers were tagged in the PR sidebar
- [x] Assignees was tagged in the PR sidebar
- [x] Labels was added in the PR sidebar
- [x] Project was added in the PR sidebar
- [x] Milestone was added in the PR sidebar

## INSERT PR DESCRIPTION BELOW
Fixed property Edit Mode return NaN propertyId

### Screenshots or Video
![image](https://github.com/explore-siargao/es-main/assets/109063409/694bcdef-2575-4ed6-baf6-7977baecc70f)