### PR TITLE
[Bug-Feature] Fixed do not render additional policy if policy is empty in summary

### DIFF
--- a/apps/web/module/Hosting/Listings/Properties/Property/Summary/index.tsx
+++ b/apps/web/module/Hosting/Listings/Properties/Property/Summary/index.tsx
@@ -44,6 +44,12 @@ const Summary = () => {
     await mutate(newStatus, callBackReq)
   }
 
+  const filteredPolicies = data?.item?.policies.filter(
+    (policy: T_Property_Policy) =>
+      policy.isSelected === true &&
+      !(policy.category === "Additional Rules" && !policy.policy)
+  )
+
   return (
     <div className="mt-20 mb-28">
       {isPending ? (
@@ -306,14 +312,10 @@ const Summary = () => {
               >
                 Property Policies
               </Typography>
-              {data?.item?.policies.length > 0 ? (
+              {filteredPolicies.length > 0 ? (
                 <ol className="list-decimal text-sm space-y-2 mt-2 ml-3.5">
-                  {data?.item?.policies
-                    .filter(
-                      (policy: T_Property_Policy) => policy.isSelected === true
-                    )
-                    .sort((a: any, b: any) => {
-                      console.log(a.category, b.category)
+                  {filteredPolicies
+                    .sort((a: T_Property_Policy, b: T_Property_Policy) => {
                       if (a.category < b.category) {
                         return -1
                       }


### PR DESCRIPTION
## REMINDER OF THE REQUIRED ACTIONS

- [x] No console message/errors/warning thrown to the logs
- [x] Have run `pnpm run build` and no failing builds shown
- [x] Commit messages was squashed to a single commit [Tutorial](https://www.youtube.com/watch?v=DLadleLj0ic)
- [x] Reviewers were tagged in the PR sidebar
- [x] Assignees was tagged in the PR sidebar
- [x] Labels was added in the PR sidebar
- [x] Project was added in the PR sidebar
- [x] Milestone was added in the PR sidebar

## INSERT PR DESCRIPTION BELOW
Fixed do not render additional policy if policy is empty in summary

### Screenshots or Video
![image](https://github.com/explore-siargao/es-main/assets/109063409/a38a7155-b436-4fc7-b700-348c52cfc399)