### PR TITLE
[Story-Feature] Disabled Property type options in edit property type

### DIFF
--- a/apps/web/module/Hosting/Listings/Properties/Property/PropertyType.tsx
+++ b/apps/web/module/Hosting/Listings/Properties/Property/PropertyType.tsx
@@ -126,8 +126,10 @@ const PropertyType = ({ pageType }: Prop) => {
         {PROPERTY_TYPES.map((property) => (
           <div
             key={property.description}
-            className={`${(property.isSelected && selectedProperty === "") || selectedProperty === property.type ? "border-2 border-secondary-500" : "border border-gray-300"} rounded-lg p-4 hover:cursor-pointer hover:bg-gray-50 select-none`}
-            onClick={() => setSelectedProperty(property.type)}
+            className={`${(property.isSelected && selectedProperty === "") || selectedProperty === property.type ? "border-2 border-secondary-500" : "border border-gray-300"} rounded-lg p-4 ${pageType === "setup" ? "hover:cursor-pointer hover:bg-gray-50" : "cursor-not-allowed"} select-none`} // Updated className to disable selection if pageType is 'edit'
+            onClick={() =>
+              pageType === "setup" && setSelectedProperty(property.type)
+            }
           >
             {(property.isSelected && selectedProperty === "") ||
             selectedProperty === property.type ? (


### PR DESCRIPTION
## REMINDER OF THE REQUIRED ACTIONS

- [x] No console message/errors/warning thrown to the logs
- [x] Have run `pnpm run build` and no failing builds shown
- [x] Commit messages was squashed to a single commit [Tutorial](https://www.youtube.com/watch?v=DLadleLj0ic)
- [x] Reviewers were tagged in the PR sidebar
- [x] Assignees was tagged in the PR sidebar
- [x] Labels was added in the PR sidebar
- [x] Project was added in the PR sidebar
- [x] Milestone was added in the PR sidebar

## INSERT PR DESCRIPTION BELOW
Disabled Property type options in edit property type

### Screenshots or Video
![image](https://github.com/explore-siargao/es-main/assets/109063409/ce90c036-b69e-4aae-a1eb-0d330fb64eb7)