### PR TITLE
[Bug-Feature] Fixed error on saving rental price required field cannot be…

### DIFF
--- a/apps/web/module/Hosting/Listings/Rentals/Rental/Pricing/index.tsx
+++ b/apps/web/module/Hosting/Listings/Rentals/Rental/Pricing/index.tsx
@@ -24,7 +24,7 @@ const Pricing = ({ pageType }: Prop) => {
   const { data, isLoading } = useGetRentalPricing(listingId)
   const { mutate, isPending } = useUpdateRentalPricing(listingId)
   const { register, handleSubmit } = useForm<T_Rental_Pricing>({
-    values: data?.item?.Pricing as T_Rental_Pricing,
+    values: data?.item as T_Rental_Pricing,
   })
 
   const onSubmit = (formData: T_Rental_Pricing) => {


### PR DESCRIPTION
… empty even if theres a value

## REMINDER OF THE REQUIRED ACTIONS

- [x] No console message/errors/warning thrown to the logs
- [x] Have run `pnpm run build` and no failing builds shown
- [x] Commit messages was squashed to a single commit [Tutorial](https://www.youtube.com/watch?v=DLadleLj0ic)
- [x] Reviewers were tagged in the PR sidebar
- [x] Assignees was tagged in the PR sidebar
- [x] Labels was added in the PR sidebar
- [x] Project was added in the PR sidebar
- [x] Milestone was added in the PR sidebar

## INSERT PR DESCRIPTION BELOW

### Comments

Fixed error on saving rental price required field cannot be empty even if theres a value

### Screenshots or Video

![image](https://github.com/explore-siargao/es-main/assets/29083384/0ba6bebe-af53-4070-9a5a-46be573a7938)
