### PR TITLE
[Story - Main] Added endpoint for getting rentals names by host and category

### DIFF
--- a/apps/api/src/routes/api/rentals/index.ts
+++ b/apps/api/src/routes/api/rentals/index.ts
@@ -34,6 +34,7 @@ import {
   getCarCalendar,
   getMotorcycleCalendar,
 } from './services/calendar'
+import { getRentalsByHostAndCategory } from './services/rentals'
 
 const router = express.Router()
 
@@ -249,7 +250,13 @@ router.get(
   getCarCalendar
 )
 
-// rental counts
-router.get('/counts/all', isOriginValid, isUserLoggedIn, getRentalCounts)
+// rentals
+router.get(
+  '/:category/list',
+  isOriginValid,
+  isUserLoggedIn,
+  isCsrfTokenValid,
+  getRentalsByHostAndCategory
+)
 
 export default router

--- a/apps/api/src/routes/api/rentals/index.ts
+++ b/apps/api/src/routes/api/rentals/index.ts
@@ -6,8 +6,7 @@ import {
   getRentalDetails,
   getRental,
   deleteRental,
-  getAllRentalsByHostId,
-  getRentalCounts,
+  getAllRentalsByHostId
 } from './services/default'
 import isCsrfTokenValid from '@/common/middleware/auth/isCsrfTokenValid3'
 import isUserLoggedIn from '@/common/middleware/auth/isUserLoggedIn3'

--- a/apps/api/src/routes/api/rentals/services/rentals.ts
+++ b/apps/api/src/routes/api/rentals/services/rentals.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from 'express'
+import { ResponseService } from '@/common/service/response'
+import { dbRentals } from '@repo/database'
+import { UNKNOWN_ERROR_OCCURRED } from '@/common/constants'
+
+const response = new ResponseService()
+
+export const getRentalsByHostAndCategory = async (
+  req: Request,
+  res: Response
+) => {
+  try {
+    const { category } = req.params
+    const hostId = res.locals.user.id
+
+    // Validate category
+    if (!['Car', 'Motorbike', 'Bicycle'].includes(category as string)) {
+      return res.json(
+        response.error({
+          message: 'Invalid category. Must be Car, Motorbike, or Bicycle.',
+        })
+      )
+    }
+
+    const rentals = await dbRentals.find({ host: hostId, category })
+    let results: any = null
+    if (category === 'Car' || category === 'Motorbike') {
+      results = rentals.map((rental) => ({
+        name: `${rental.year} ${rental.make} ${rental.modelBadge} ${rental.transmission === 'Automatic' ? 'AT' : 'MT'}`,
+      }))
+    } else {
+      results = rentals.map((rental) => ({
+        name: `${rental.make}`,
+      }))
+    }
+
+    return res.json(
+      response.success({ items: results, allItemCount: rentals.length })
+    )
+  } catch (err: any) {
+    return res.json(
+      response.error({
+        message: err.message ? err.message : UNKNOWN_ERROR_OCCURRED,
+      })
+    )
+  }
+}


### PR DESCRIPTION
## REMINDER OF THE REQUIRED ACTIONS

- [x] No console message/errors/warning thrown to the logs
- [x] Have run `pnpm run build` and no failing builds shown
- [x] Commit messages was squashed to a single commit [Tutorial](https://www.youtube.com/watch?v=DLadleLj0ic)
- [x] Reviewers were tagged in the PR sidebar
- [x] Assignees was tagged in the PR sidebar
- [x] Labels was added in the PR sidebar
- [x] Project was added in the PR sidebar
- [x] Milestone was added in the PR sidebar

## INSERT PR DESCRIPTION BELOW

### Comments

Added endpoint for getting rentals names by host and category

### Screenshots or Video

![image](https://github.com/user-attachments/assets/203d1f66-05c7-486f-81ec-8fbcbb9ad0ae)
