### PR TITLE
[Story-Feature] Modified visibility of preview listing button based on status

### DIFF
--- a/apps/web/common/components/HostLayout/ListingHeader/index.tsx
+++ b/apps/web/common/components/HostLayout/ListingHeader/index.tsx
@@ -141,14 +141,17 @@ function ListingHeader({
             </div>
           </div>
           <div className="hidden lg:flex lg:flex-1 lg:justify-end space-x-3 gap-3 items-center relative">
-            <Link
-              href={`${category === "Activity" ? LINK_LISTINGS_ACTIVITY : category === "Rental" ? LINK_LISTINGS_RENTAL : LINK_LISTINGS_PROPERTY}/${listingId}`}
-              target="_blank"
-            >
-              <Button variant="secondary" size="sm" className="flex gap-2">
-                <LucideEye className="h-4 w-4" /> Preview listing
-              </Button>
-            </Link>
+            {data?.item?.status === "Pending" && (
+              <Link
+                href={`${category === "Activity" ? LINK_LISTINGS_ACTIVITY : category === "Rental" ? LINK_LISTINGS_RENTAL : LINK_LISTINGS_PROPERTY}/${listingId}`}
+                target="_blank"
+              >
+                <Button variant="secondary" size="sm" className="flex gap-2">
+                  <LucideEye className="h-4 w-4" /> Preview listing
+                </Button>
+              </Link>
+            )}
+
             {listingStatus === E_Listing_Status.edit && (
               <Button
                 variant="primary"


### PR DESCRIPTION
## REMINDER OF THE REQUIRED ACTIONS

- [x] No console message/errors/warning thrown to the logs
- [x] Have run `pnpm run build` and no failing builds shown
- [x] Commit messages was squashed to a single commit [Tutorial](https://www.youtube.com/watch?v=DLadleLj0ic)
- [x] Reviewers were tagged in the PR sidebar
- [x] Assignees was tagged in the PR sidebar
- [x] Labels was added in the PR sidebar
- [x] Project was added in the PR sidebar
- [x] Milestone was added in the PR sidebar

## INSERT PR DESCRIPTION BELOW

### Comments

Modified visibility of preview listing button based on status

### Screenshots or Video

![image](https://github.com/user-attachments/assets/36c81513-8327-436f-bfb2-f147c2dda4f9)

