### PR TITLE
[Story - Main] Automatic changing of reservation status base from current…

### DIFF
--- a/apps/api/src/routes/api/rentals/services/calendar.ts
+++ b/apps/api/src/routes/api/rentals/services/calendar.ts
@@ -63,7 +63,8 @@ const hasDateConflict = (
 export const getCarCalendar = async (req: Request, res: Response) => {
   const startDate = new Date(req.query.startDate as string)
   const endDate = new Date(req.query.endDate as string)
-
+  const currentDate = new Date()
+  currentDate.setUTCHours(0, 0, 0, 0)
   try {
     const carRentals = await dbRentals
       .find({ category: 'Car', host: res.locals.user.id })
@@ -92,6 +93,22 @@ export const getCarCalendar = async (req: Request, res: Response) => {
     const reservationMap: Record<string, Reservation[]> = {}
     reservations.forEach((reservation: any) => {
       const guest = reservation.guest
+      let reservationStatus = reservation.status
+      if (
+        (reservationStatus === 'Confirmed' || reservationStatus === 'Blocked-Dates') &&
+        currentDate >= reservation.startDate &&
+        currentDate <= reservation.endDate
+      ) {
+        reservationStatus = 'Checked-In' // Update the status to 'Checked-In'
+      }
+      else if (
+        (reservationStatus === 'Confirmed' || reservationStatus === 'Blocked-Dates'
+          || reservationStatus === 'Checked-In'
+        ) &&
+        currentDate > reservation.endDate
+      ) {
+        reservationStatus = 'Checked-Out' // Update the status to 'Checked-Out'
+      }
       const reservationItem: Reservation = {
         id: reservation._id,
         name: STATUS_DISPLAY.includes(reservation.status)
@@ -102,7 +119,7 @@ export const getCarCalendar = async (req: Request, res: Response) => {
         startDate: reservation.startDate ?? new Date(),
         endDate: reservation.endDate ?? new Date(),
         guestCount: reservation.guestCount ?? 0,
-        status: reservation.status,
+        status: reservationStatus,
         notes: reservation.notes,
       }
 
@@ -153,7 +170,8 @@ export const getCarCalendar = async (req: Request, res: Response) => {
 export const getBikeCalendar = async (req: Request, res: Response) => {
   const startDate = new Date(req.query.startDate as string)
   const endDate = new Date(req.query.endDate as string)
-
+  const currentDate = new Date()
+  currentDate.setUTCHours(0, 0, 0, 0)
   try {
     const bicycleRentals = await dbRentals
       .find({ category: 'Bicycle', host: res.locals.user.id })
@@ -182,6 +200,24 @@ export const getBikeCalendar = async (req: Request, res: Response) => {
     const reservationMap: Record<string, Reservation[]> = {}
     reservations.forEach((reservation: any) => {
       const guest = reservation.guest
+      let reservationStatus = reservation.status
+      if (
+        (reservationStatus === 'Confirmed' || reservationStatus === 'Blocked-Dates'
+          || reservationStatus === 'Checked-In'
+        ) &&
+        currentDate >= reservation.startDate &&
+        currentDate <= reservation.endDate
+      ) {
+        reservationStatus = 'Checked-In' // Update the status to 'Checked-In'
+      }
+      else if (
+        (reservationStatus === 'Confirmed' || reservationStatus === 'Blocked-Dates'
+          || reservationStatus === 'Checked-In' || reservationStatus === 'Checked-Out'
+        ) &&
+        currentDate > reservation.endDate
+      ) {
+        reservationStatus = 'Checked-Out' // Update the status to 'Checked-Out'
+      }
       const reservationItem: Reservation = {
         id: reservation._id,
         name: STATUS_DISPLAY.includes(reservation.status)
@@ -192,7 +228,7 @@ export const getBikeCalendar = async (req: Request, res: Response) => {
         startDate: reservation.startDate ?? new Date(),
         endDate: reservation.endDate ?? new Date(),
         guestCount: reservation.guestCount ?? 0,
-        status: reservation.status,
+        status: reservationStatus,
         notes: reservation.note,
       }
 
@@ -243,7 +279,8 @@ export const getBikeCalendar = async (req: Request, res: Response) => {
 export const getMotorcycleCalendar = async (req: Request, res: Response) => {
   const startDate = new Date(req.query.startDate as string)
   const endDate = new Date(req.query.endDate as string)
-
+  const currentDate = new Date()
+  currentDate.setUTCHours(0, 0, 0, 0)
   try {
     const motorcycleRentals = await dbRentals
       .find({ category: 'Motorbike', host: res.locals.user.id })
@@ -272,6 +309,24 @@ export const getMotorcycleCalendar = async (req: Request, res: Response) => {
     const reservationMap: Record<string, Reservation[]> = {}
     reservations.forEach((reservation: any) => {
       const guest = reservation.guest
+      let reservationStatus = reservation.status
+      if (
+        (reservationStatus === 'Confirmed' || reservationStatus === 'Blocked-Dates'
+          || reservationStatus === 'Checked-In'
+        ) &&
+        currentDate >= reservation.startDate &&
+        currentDate <= reservation.endDate
+      ) {
+        reservationStatus = 'Checked-In' // Update the status to 'Checked-In'
+      }
+      else if (
+        (reservationStatus === 'Confirmed' || reservationStatus === 'Blocked-Dates'
+          || reservationStatus === 'Checked-In' || reservationStatus === 'Checked-Out'
+        ) &&
+        currentDate > reservation.endDate
+      ) {
+        reservationStatus = 'Checked-Out' // Update the status to 'Checked-Out'
+      }
       const reservationItem: Reservation = {
         id: reservation._id,
         name: STATUS_DISPLAY.includes(reservation.status)
@@ -282,7 +337,7 @@ export const getMotorcycleCalendar = async (req: Request, res: Response) => {
         startDate: reservation.startDate ?? new Date(),
         endDate: reservation.endDate ?? new Date(),
         guestCount: reservation.guestCount ?? 0,
-        status: reservation.status,
+        status: reservationStatus,
         notes: reservation.notes,
       }
 

--- a/apps/api/src/routes/api/rentals/services/calendar.ts
+++ b/apps/api/src/routes/api/rentals/services/calendar.ts
@@ -95,16 +95,16 @@ export const getCarCalendar = async (req: Request, res: Response) => {
       const guest = reservation.guest
       let reservationStatus = reservation.status
       if (
-        (reservationStatus === 'Confirmed' || reservationStatus === 'Blocked-Dates') &&
+        (reservationStatus === 'Confirmed' ||
+          reservationStatus === 'Blocked-Dates') &&
         currentDate >= reservation.startDate &&
         currentDate <= reservation.endDate
       ) {
         reservationStatus = 'Checked-In' // Update the status to 'Checked-In'
-      }
-      else if (
-        (reservationStatus === 'Confirmed' || reservationStatus === 'Blocked-Dates'
-          || reservationStatus === 'Checked-In'
-        ) &&
+      } else if (
+        (reservationStatus === 'Confirmed' ||
+          reservationStatus === 'Blocked-Dates' ||
+          reservationStatus === 'Checked-In') &&
         currentDate > reservation.endDate
       ) {
         reservationStatus = 'Checked-Out' // Update the status to 'Checked-Out'
@@ -202,18 +202,18 @@ export const getBikeCalendar = async (req: Request, res: Response) => {
       const guest = reservation.guest
       let reservationStatus = reservation.status
       if (
-        (reservationStatus === 'Confirmed' || reservationStatus === 'Blocked-Dates'
-          || reservationStatus === 'Checked-In'
-        ) &&
+        (reservationStatus === 'Confirmed' ||
+          reservationStatus === 'Blocked-Dates' ||
+          reservationStatus === 'Checked-In') &&
         currentDate >= reservation.startDate &&
         currentDate <= reservation.endDate
       ) {
         reservationStatus = 'Checked-In' // Update the status to 'Checked-In'
-      }
-      else if (
-        (reservationStatus === 'Confirmed' || reservationStatus === 'Blocked-Dates'
-          || reservationStatus === 'Checked-In' || reservationStatus === 'Checked-Out'
-        ) &&
+      } else if (
+        (reservationStatus === 'Confirmed' ||
+          reservationStatus === 'Blocked-Dates' ||
+          reservationStatus === 'Checked-In' ||
+          reservationStatus === 'Checked-Out') &&
         currentDate > reservation.endDate
       ) {
         reservationStatus = 'Checked-Out' // Update the status to 'Checked-Out'
@@ -311,18 +311,18 @@ export const getMotorcycleCalendar = async (req: Request, res: Response) => {
       const guest = reservation.guest
       let reservationStatus = reservation.status
       if (
-        (reservationStatus === 'Confirmed' || reservationStatus === 'Blocked-Dates'
-          || reservationStatus === 'Checked-In'
-        ) &&
+        (reservationStatus === 'Confirmed' ||
+          reservationStatus === 'Blocked-Dates' ||
+          reservationStatus === 'Checked-In') &&
         currentDate >= reservation.startDate &&
         currentDate <= reservation.endDate
       ) {
         reservationStatus = 'Checked-In' // Update the status to 'Checked-In'
-      }
-      else if (
-        (reservationStatus === 'Confirmed' || reservationStatus === 'Blocked-Dates'
-          || reservationStatus === 'Checked-In' || reservationStatus === 'Checked-Out'
-        ) &&
+      } else if (
+        (reservationStatus === 'Confirmed' ||
+          reservationStatus === 'Blocked-Dates' ||
+          reservationStatus === 'Checked-In' ||
+          reservationStatus === 'Checked-Out') &&
         currentDate > reservation.endDate
       ) {
         reservationStatus = 'Checked-Out' // Update the status to 'Checked-Out'


### PR DESCRIPTION
… dates on rental reservation

## REMINDER OF THE REQUIRED ACTIONS

- [x] No console message/errors/warning thrown to the logs
- [x] Have run `pnpm run build` and no failing builds shown
- [x] Commit messages was squashed to a single commit [Tutorial](https://www.youtube.com/watch?v=DLadleLj0ic)
- [x] Reviewers were tagged in the PR sidebar
- [x] Assignees was tagged in the PR sidebar
- [x] Labels was added in the PR sidebar
- [x] Project was added in the PR sidebar
- [x] Milestone was added in the PR sidebar

## INSERT PR DESCRIPTION BELOW

### Comments

Automatic changing of reservation status base from current dates on rental reservation

### Screenshots or Video

![image](https://github.com/user-attachments/assets/4de0623b-9ba5-4dcb-9f9f-49c64f2c0555)
