### PR TITLE
Added endpoint for cancellation of activity reservations

### DIFF
--- a/apps/api/src/routes/api/reservations/index.ts
+++ b/apps/api/src/routes/api/reservations/index.ts
@@ -15,6 +15,7 @@ import {
 import {
   addJoinerActivityReservation,
   addPrivateActivityReservation,
+  cancelActivityReservation,
 } from './services/activityReservation'
 
 const router = express.Router()
@@ -84,5 +85,13 @@ router.patch(
   isUserLoggedIn,
   isCsrfTokenValid,
   cancelUnitReservationByHost
+)
+
+router.patch(
+  '/activity/:reservationId/cancel-reservation',
+  isOriginValid,
+  isUserLoggedIn,
+  isCsrfTokenValid,
+  cancelActivityReservation
 )
 export default router


### PR DESCRIPTION
## REMINDER OF THE REQUIRED ACTIONS

- [x] No console message/errors/warning thrown to the logs
- [x] Have run `pnpm run build` and no failing builds shown
- [x] Commit messages was squashed to a single commit [Tutorial](https://www.youtube.com/watch?v=DLadleLj0ic)
- [x] Reviewers were tagged in the PR sidebar
- [x] Assignees was tagged in the PR sidebar
- [x] Labels was added in the PR sidebar
- [x] Project was added in the PR sidebar
- [x] Milestone was added in the PR sidebar

## INSERT PR DESCRIPTION BELOW

### Comments

Added endpoint for cancellation of activity reservations

### Screenshots or Video

![image](https://github.com/user-attachments/assets/893b59a9-9e00-495c-8261-78f2099a1b87)
